### PR TITLE
Allow disabling remote method after initialize explorer

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,6 +104,12 @@ function mountSwagger(loopbackApplication, swaggerApp, opts) {
     swaggerObject = createSwaggerObject(loopbackApplication, opts);
   });
 
+  // listening to remoteMethodDisabled event for updating the swaggerObject
+  // when a remote method is disabled to hide that method in the Swagger UI.
+  loopbackApplication.on('remoteMethodDisabled', function() {
+    swaggerObject = createSwaggerObject(loopbackApplication, opts);
+  });
+
   var resourcePath = opts && opts.resourcePath || 'swagger.json';
   if (resourcePath[0] !== '/') resourcePath = '/' + resourcePath;
 

--- a/test/explorer.test.js
+++ b/test/explorer.test.js
@@ -283,6 +283,37 @@ describe('explorer', function() {
       });
   });
 
+  it('updates swagger object when a remote method is disabled', function(done) {
+    var app = loopback();
+    configureRestApiAndExplorer(app, '/explorer');
+
+    // Ensure the swagger object was built
+    request(app)
+      .get('/explorer/swagger.json')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) return done(err);
+
+        // Check the method that will be disabled
+        var paths = Object.keys(res.body.paths);
+        expect(paths).to.contain('/products/findOne');
+
+        var Product = app.models.Product;
+        Product.disableRemoteMethod('findOne', true);
+
+        // Request swagger.json again
+        request(app)
+          .get('/explorer/swagger.json')
+          .expect(200)
+          .end(function(err, res) {
+            if (err) return done(err);
+            var paths = Object.keys(res.body.paths);
+            expect(paths).to.not.contain('/products/findOne');
+            done();
+          });
+      });
+  });
+
   function givenLoopBackAppWithExplorer(explorerBase) {
     return function(done) {
       var app = this.app = loopback();


### PR DESCRIPTION
This PR is for strongloop/loopback#686 to make the explorer registering a remoteMethodDisabled event that is fired from PR strongloop/loopback#2266. The explorer will update a swagger object when getting this event to hide the disabled remote method.