### PR TITLE
Upgrade loopback devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "chai": "^3.2.0",
     "eslint": "^2.8.0",
     "eslint-config-loopback": "^2.0.0",
-    "loopback": "^2.19.1",
+    "loopback": "^2.28.0",
     "mocha": "^2.2.5",
     "supertest": "^1.0.1"
   },


### PR DESCRIPTION
The "hide disabled remote methods after explorer is initialized" feature requires loopback 2.28.0. So, upgrade devDependency to make it more explicit about minimum requirement.