### PR TITLE
Redirect get http 301 instead of 303

### DIFF
--- a/test/explorer.test.js
+++ b/test/explorer.test.js
@@ -24,7 +24,7 @@ describe('explorer', function() {
     it('should redirect to /explorer/', function(done) {
       request(this.app)
         .get('/explorer')
-        .expect(303)
+        .expect(301)
         .end(done);
     });
 


### PR DESCRIPTION
Connect to CI failure: https://github.com/strongloop-internal/scrum-loopback/issues/915#issuecomment-226798303

Redirect to /explorer/ expects a http 301 instead of 303.