### PR TITLE
Deprecate built-in CORS middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var g = SG();
 /*!
  * Adds dynamically-updated docs as /explorer
  */
+var deprecated = require('depd')('loopback-explorer');
 var url = require('url');
 var path = require('path');
 var urlJoin = require('./lib/url-join');
@@ -133,9 +134,19 @@ function mountSwagger(loopbackApplication, swaggerApp, opts) {
 }
 
 function setupCors(swaggerApp, remotes) {
-  var corsOptions = remotes.options && remotes.options.cors ||
-  { origin: true, credentials: true };
+  var corsOptions = remotes.options && remotes.options.cors;
+  if (corsOptions === false)
+    return;
 
-  // TODO(bajtos) Skip CORS when remotes.options.cors === false
+  deprecated(g.f(
+    'The built-in CORS middleware provided by loopback-component-explorer ' +
+      'was deprecated. See %s for more details.',
+    'https://docs.strongloop.com/display/public/LB/Security+considerations'
+  ));
+
+  if (corsOptions === undefined) {
+    corsOptions = { origin: true, credentials: true };
+  }
+
   swaggerApp.use(cors(corsOptions));
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "cors": "^2.7.1",
     "debug": "^2.2.0",
+    "depd": "^1.1.0",
     "lodash": "^3.10.0",
     "loopback-swagger": "^2.1.0",
     "strong-globalize": "^2.6.2",

--- a/test/explorer.test.js
+++ b/test/explorer.test.js
@@ -87,6 +87,7 @@ describe('explorer', function() {
     it('should serve correct swagger-ui config', function(done) {
       var app = loopback();
       app.set('restApiRoot', '/rest-api-root');
+      app.set('remoting', { cors: false });
       configureRestApiAndExplorer(app);
 
       request(app)
@@ -108,6 +109,7 @@ describe('explorer', function() {
       // if the basePath ends with a slash too, an incorrect URL is produced
       var app = loopback();
       app.set('restApiRoot', '/apis/');
+      app.set('remoting', { cors: false });
       configureRestApiAndExplorer(app);
 
       request(app)
@@ -129,6 +131,7 @@ describe('explorer', function() {
     var app;
     beforeEach(function setupExplorerWithUiDirs() {
       app = loopback();
+      app.set('remoting', { cors: false });
       explorer(app, {
         uiDirs: [path.resolve(__dirname, 'fixtures', 'dummy-swagger-ui')],
       });
@@ -160,6 +163,7 @@ describe('explorer', function() {
     var app;
     beforeEach(function setupExplorerWithoutUI() {
       app = loopback();
+      app.set('remoting', { cors: false });
       explorer(app, {
         swaggerUI: false,
       });
@@ -195,6 +199,7 @@ describe('explorer', function() {
     var app;
     beforeEach(function() {
       app = loopback();
+      app.set('remoting', { cors: false });
       var Product = loopback.PersistedModel.extend('product');
       Product.attachTo(loopback.memory());
       app.model(Product);
@@ -216,6 +221,7 @@ describe('explorer', function() {
     var app;
     beforeEach(function() {
       app = loopback();
+      app.set('remoting', { cors: false });
     });
 
     it('should allow `uiDirs` to be defined as an Array', function(done) {
@@ -246,6 +252,7 @@ describe('explorer', function() {
   describe('Cross-origin resource sharing', function() {
     it('allows cross-origin requests by default', function(done) {
       var app = loopback();
+      process.once('deprecation', function() { /* ignore */ });
       configureRestApiAndExplorer(app, '/explorer');
 
       request(app)
@@ -258,7 +265,7 @@ describe('explorer', function() {
 
     it('can be disabled by configuration', function(done) {
       var app = loopback();
-      app.set('remoting', { cors: { origin: false }});
+      app.set('remoting', { cors: false });
       configureRestApiAndExplorer(app, '/explorer');
 
       request(app)
@@ -277,6 +284,7 @@ describe('explorer', function() {
 
   it('updates swagger object when a new model is added', function(done) {
     var app = loopback();
+    app.set('remoting', { cors: false });
     configureRestApiAndExplorer(app, '/explorer');
 
     // Ensure the swagger object was built
@@ -310,6 +318,7 @@ describe('explorer', function() {
 
   it('updates swagger object when a remote method is disabled', function(done) {
     var app = loopback();
+    app.set('remoting', { cors: false });
     configureRestApiAndExplorer(app, '/explorer');
 
     // Ensure the swagger object was built
@@ -344,6 +353,7 @@ describe('explorer', function() {
   function givenLoopBackAppWithExplorer(explorerBase) {
     return function(done) {
       var app = this.app = loopback();
+      app.set('remoting', { cors: false });
       configureRestApiAndExplorer(app, explorerBase);
 
       done();


### PR DESCRIPTION
Push the responsibility of enabling/configuring CORS back to the application developer.

This is a follow-up for https://github.com/strongloop/strong-remoting/pull/352 and https://github.com/strongloop/strong-remoting/pull/357 which removed (3.x)/deprecated (2.x) the built-in CORS middleware in strong-remoting.

@richardpringle please review
