### PR TITLE
Fix CORS tests when running on LoopBack v3

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,9 +133,13 @@ function mountSwagger(loopbackApplication, swaggerApp, opts) {
 }
 
 function setupCors(swaggerApp, remotes) {
-  var corsOptions = remotes.options && remotes.options.cors ||
-  { origin: true, credentials: true };
+  var corsOptions = remotes.options && remotes.options.cors;
+  if (corsOptions === false)
+    return;
 
-  // TODO(bajtos) Skip CORS when remotes.options.cors === false
+  if (corsOptions === undefined) {
+    corsOptions = { origin: true, credentials: true };
+  }
+
   swaggerApp.use(cors(corsOptions));
 }

--- a/test/explorer.test.js
+++ b/test/explorer.test.js
@@ -258,7 +258,7 @@ describe('explorer', function() {
 
     it('can be disabled by configuration', function(done) {
       var app = loopback();
-      app.set('remoting', { cors: { origin: false }});
+      app.set('remoting', { cors: false });
       configureRestApiAndExplorer(app, '/explorer');
 
       request(app)


### PR DESCRIPTION
Rework the test suite to disable cors via `{cors: false}` instead of `{cors: {origin: false}}`, because the latter is no longer supported by strong-remoting.

This is an alternative to #178

@richardpringle PTAL