### PR TITLE
Update loopback-swagger dependency to 2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "debug": "^2.2.0",
     "depd": "^1.1.0",
     "lodash": "^3.10.0",
-    "loopback-swagger": "^2.1.0",
+    "loopback-swagger": "^2.8.0",
     "strong-globalize": "^2.6.2",
     "swagger-ui": "^2.2.5"
   }


### PR DESCRIPTION
### Description
The [loopback-swagger](https://github.com/strongloop/loopback-swagger) dependency is out of date and is missing at least one patch that fixes Swagger API generation when dates are used.

The workaround right now is using `npm shrinkwrap` which requires either forking this repository and using it in the loopback application or putting a shrinkwrap around the entire loopback app's dependency tree. Being able to just `npm install` and have Swagger API's work would be wonderful :)

#### Related issues
#199 
strongloop/loopback-swagger#35

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
