### PR TITLE
bump loopback-swagger version to 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "debug": "^2.2.0",
     "depd": "^1.1.0",
     "lodash": "^3.10.0",
-    "loopback-swagger": "^2.1.0",
+    "loopback-swagger": "^3.0.1",
     "strong-globalize": "^2.6.2",
     "swagger-ui": "^2.2.5"
   }


### PR DESCRIPTION
### Description
Compared to #200 I'd like to apply the version to 3.0.1, for the reason of `default: null` being filtered out of the swagger.json since 22nd of december 2016. Please do as you like (:

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
