### PR TITLE
Set z-index to 1 on header to fix styling bug

### DIFF
--- a/public/css/loopbackStyles.css
+++ b/public/css/loopbackStyles.css
@@ -25,6 +25,7 @@ body #header {
   position: fixed;
   width: 100%;
   top: 0;
+  z-index: 1;
 }
 
 body #header a#logo {


### PR DESCRIPTION
### Description
Sometimes fields are hovering over the header

![2017-02-15_180558](https://cloud.githubusercontent.com/assets/8213031/22971912/fe0b039a-f3a9-11e6-95e0-6803339e9f3d.png)
