### PR TITLE
Change Explorer header to use LoopBack vs StrongLoop

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>StrongLoop API Explorer</title>
+  <title>LoopBack API Explorer</title>
   <link href='css/typography.css' media='screen' rel='stylesheet' type='text/css'/>
   <link href='css/reset.css' media='screen' rel='stylesheet' type='text/css'/>
   <link href='css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
@@ -33,7 +33,7 @@
 <body class="swagger-section standalone">
 <div id='header'>
     <div class="swagger-ui-wrap">
-        <a id="logo">StrongLoop API Explorer</a>
+        <a id="logo">LoopBack API Explorer</a>
         <form id='api_selector'>
             <div class='input'>
                 <span class='accessTokenDisplay'>Token Not Set</span>

--- a/test/explorer.test.js
+++ b/test/explorer.test.js
@@ -36,7 +36,7 @@ describe('explorer', function() {
         .end(function(err, res) {
           if (err) throw err;
 
-          assert(!!~res.text.indexOf('<title>StrongLoop API Explorer</title>'),
+          assert(!!~res.text.indexOf('<title>LoopBack API Explorer</title>'),
             'text does not contain expected string');
 
           done();


### PR DESCRIPTION


### Description
Sumitha asked if we could change the title of the LoopBack explorer to read LoopBack API Explorer instead of StrongLoop API Explorer.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
