### PR TITLE
adding on started listener to display nestRemoting method in swagger …

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,6 +122,13 @@ function mountSwagger(loopbackApplication, swaggerApp, opts) {
     swaggerObject = createSwaggerObject(loopbackApplication, opts);
   });
 
+  // listening to started event for updating the swaggerObject
+  // when a call to app.models.[modelName].nestRemoting([modelName])
+  // to appear that method in the Swagger UI.
+  loopbackApplication.on('started', function() {
+    swaggerObject = createSwaggerObject(loopbackApplication, opts);
+  });
+
   var resourcePath = opts && opts.resourcePath || 'swagger.json';
   if (resourcePath[0] !== '/') resourcePath = '/' + resourcePath;
 

--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ function mountSwagger(loopbackApplication, swaggerApp, opts) {
   // listening to started event for updating the swaggerObject
   // when a call to app.models.[modelName].nestRemoting([modelName])
   // to appear that method in the Swagger UI.
-  loopbackApplication.on('started', function() {
+  loopbackApplication.on('remoteMethodAdded', function() {
     swaggerObject = createSwaggerObject(loopbackApplication, opts);
   });
 


### PR DESCRIPTION
### Description

Add _nestRemoting_ routes in the explorer

#### Related issues

- #167 
- strongloop/loopback#2409

<!--
Please use the following link syntaxes:

- #167 (to reference issues in the current repository)
- strongloop/loopback#2409 (to reference issues in another repository)
-->

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
