### PR TITLE
Increment loopback-swagger version to 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "debug": "^2.2.0",
     "depd": "^1.1.0",
     "lodash": "^3.10.0",
-    "loopback-swagger": "^3.0.1",
+    "loopback-swagger": "^4.0.0",
     "strong-globalize": "^2.6.2",
     "swagger-ui": "^2.2.5"
   }


### PR DESCRIPTION
Increment loopback-swagger version to ^4.0.0 which supports updateOnly feature. Without this loopback-cli --> create new app --> will not pick up the new 'updateOnly' feature https://github.com/strongloop/loopback/issues/2924