### PR TITLE
Increment package version to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-component-explorer",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "description": "Browse and test your LoopBack app's APIs",
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
Current master points to  "loopback-swagger": "^4.0.0" which has "updateOnly" support. 
@raymondfeng PTAL