### PR TITLE
CODEOWNERS: turn off PR notifications for STRML

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,5 +2,8 @@
 # Each line is a file pattern followed by one or more owners,
 # the last matching pattern has the most precendence.
 
-# Core team members from IBM and maintainers
-* @bajtos @STRML
+# People watching and approving all pull requests
+* @bajtos
+
+# Maintainers that do not wish to be notified about new pull requests
+_ @STRML


### PR DESCRIPTION
See https://github.com/strongloop/loopback-component-explorer/pull/219#issuecomment-326441810

> Could you please take me off the automatic review bot?

@STRML sorry for the inconvenience. This pull request should disable PR review notifications for you in this repository, see [this github docs](https://help.github.com/articles/about-codeowners/) for more details about CODEOWNERS.

I think you are listed as a code owner in few more repositories. I there are any other repositories where you are receiving PR review requests that you are not interested in, then please open a pull request to apply a similar changes to CODEOWERS as done in this patch, or let me know e.g. on Gitter and I can do that myself.