### PR TITLE
Upgrade lodash from 3.x to 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "cors": "^2.7.1",
     "debug": "^2.2.0",
     "depd": "^1.1.0",
-    "lodash": "^3.10.0",
+    "lodash": "^4.17.5",
     "loopback-swagger": "^5.0.0",
     "strong-globalize": "^3.1.0",
     "swagger-ui": "^2.2.5"


### PR DESCRIPTION
This change fixes the following security vulnerability:
 - [npm:lodash:20180130](https://snyk.io/vuln/npm:lodash:20180130)