### PR TITLE
[SEMVER-MAJOR] Remove deprecated CORS support

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,12 +12,10 @@ var g = SG();
 /*!
  * Adds dynamically-updated docs as /explorer
  */
-var deprecated = require('depd')('loopback-explorer');
 var url = require('url');
 var path = require('path');
 var urlJoin = require('./lib/url-join');
 var _defaults = require('lodash').defaults;
-var cors = require('cors');
 var createSwaggerObject = require('loopback-swagger').generateSwaggerSpec;
 var SWAGGER_UI_ROOT = require('swagger-ui/index').dist;
 var STATIC_ROOT = path.join(__dirname, 'public');
@@ -135,9 +133,6 @@ function mountSwagger(loopbackApplication, swaggerApp, opts) {
   var resourcePath = (opts && opts.resourcePath) || 'swagger.json';
   if (resourcePath[0] !== '/') resourcePath = '/' + resourcePath;
 
-  var remotes = loopbackApplication.remotes();
-  setupCors(swaggerApp, remotes);
-
   swaggerApp.get(resourcePath, function sendSwaggerObject(req, res) {
     res.status(200).send(swaggerObject);
   });
@@ -145,23 +140,4 @@ function mountSwagger(loopbackApplication, swaggerApp, opts) {
   function rebuildSwaggerObject() {
     swaggerObject = createSwaggerObject(loopbackApplication, opts);
   }
-}
-
-function setupCors(swaggerApp, remotes) {
-  var corsOptions = remotes.options && remotes.options.cors;
-  if (corsOptions === false) return;
-
-  deprecated(
-    g.f(
-      'The built-in CORS middleware provided by loopback-component-explorer ' +
-        'was deprecated. See %s for more details.',
-      'https://loopback.io/doc/en/lb3/Security-considerations.html'
-    )
-  );
-
-  if (corsOptions === undefined) {
-    corsOptions = { origin: true, credentials: true };
-  }
-
-  swaggerApp.use(cors(corsOptions));
 }

--- a/package.json
+++ b/package.json
@@ -35,9 +35,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "cors": "^2.7.1",
     "debug": "^2.2.0",
-    "depd": "^1.1.0",
     "lodash": "^4.17.5",
     "loopback-swagger": "^5.0.0",
     "strong-globalize": "^3.1.0",

--- a/test/explorer.test.js
+++ b/test/explorer.test.js
@@ -258,39 +258,6 @@ describe('explorer', function() {
     });
   });
 
-  describe('Cross-origin resource sharing', function() {
-    it('allows cross-origin requests by default', function(done) {
-      var app = loopback();
-      process.once('deprecation', function() { /* ignore */ });
-      configureRestApiAndExplorer(app, '/explorer');
-
-      request(app)
-        .options('/explorer/swagger.json')
-        .set('Origin', 'http://example.com/')
-        .expect('Access-Control-Allow-Origin', /^http:\/\/example.com\/|\*/)
-        .expect('Access-Control-Allow-Methods', /\bGET\b/)
-        .end(done);
-    });
-
-    it('can be disabled by configuration', function(done) {
-      var app = loopback();
-      app.set('remoting', { cors: false });
-      configureRestApiAndExplorer(app, '/explorer');
-
-      request(app)
-        .options('/explorer/swagger.json')
-        .end(function(err, res) {
-          if (err) return done(err);
-
-          var allowOrigin = res.get('Access-Control-Allow-Origin');
-          expect(allowOrigin, 'Access-Control-Allow-Origin')
-            .to.equal(undefined);
-
-          done();
-        });
-    });
-  });
-
   it('updates swagger object when a new model is added', function(done) {
     var app = loopback();
     app.set('remoting', { cors: false });


### PR DESCRIPTION
When I use loopback 3, and initialize the explorer component,
I get an annoying warning when remotes.options.cors is undefined.

loopback-explorer deprecated The built-in CORS middleware provided by loopback-component-explorer was deprecated. See https://docs.strongloop.com/display/public/LB/Security+considerations for more details. server/server.js:29:3
loopback-explorer deprecated The built-in CORS middleware provided by loopback-component-explorer was deprecated. See https://docs.strongloop.com/display/public/LB/Security+considerations for more details. node_modules/loopback-boot/lib/executor.js:445:5

I think it could be solved with this little validation.