### PR TITLE
docs: update docs link away from docs.strongloop.com

### DIFF
--- a/example/hidden.js
+++ b/example/hidden.js
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+'use strict';
 var g = require('strong-globalize')();
 
 var loopback = require('loopback');
@@ -10,17 +11,21 @@ var app = loopback();
 var explorer = require('../');
 var port = 3000;
 
-var User = loopback.Model.extend('user', {
-  username: 'string',
-  email: 'string',
-  sensitiveInternalProperty: 'string',
-}, { hidden: ['sensitiveInternalProperty'] });
+var User = loopback.Model.extend(
+  'user',
+  {
+    username: 'string',
+    email: 'string',
+    sensitiveInternalProperty: 'string',
+  },
+  {hidden: ['sensitiveInternalProperty']}
+);
 
 User.attachTo(loopback.memory());
 app.model(User);
 
 var apiPath = '/api';
-explorer(app, { basePath: apiPath });
+explorer(app, {basePath: apiPath});
 app.use(apiPath, loopback.rest());
 g.log('{{Explorer}} mounted at {{localhost:%s/explorer}}', port);
 

--- a/example/simple.js
+++ b/example/simple.js
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+'use strict';
 var g = require('strong-globalize')();
 
 var loopback = require('loopback');
@@ -11,15 +12,15 @@ var explorer = require('../');
 var port = 3000;
 
 var Product = loopback.PersistedModel.extend('product', {
-  foo: { type: 'string', required: true },
+  foo: {type: 'string', required: true},
   bar: 'string',
-  aNum: { type: 'number', min: 1, max: 10, required: true, default: 5 },
+  aNum: {type: 'number', min: 1, max: 10, required: true, default: 5},
 });
 Product.attachTo(loopback.memory());
 app.model(Product);
 
 var apiPath = '/api';
-explorer(app, { basePath: apiPath });
+explorer(app, {basePath: apiPath});
 app.use(apiPath, loopback.rest());
 g.log('{{Explorer}} mounted at {{http://localhost:%s/explorer}}', port);
 

--- a/index.js
+++ b/index.js
@@ -33,19 +33,26 @@ explorer.routes = routes;
  */
 
 function explorer(loopbackApplication, options) {
-  options = _defaults({}, options, { mountPath: '/explorer' });
-  loopbackApplication.use(options.mountPath, routes(loopbackApplication, options));
+  options = _defaults({}, options, {mountPath: '/explorer'});
+  loopbackApplication.use(
+    options.mountPath,
+    routes(loopbackApplication, options)
+  );
   loopbackApplication.set('loopback-component-explorer', options);
 }
 
 function routes(loopbackApplication, options) {
   var loopback = loopbackApplication.loopback;
-  var loopbackMajor = loopback && loopback.version &&
-  loopback.version.split('.')[0] || 1;
+  var loopbackMajor =
+    (loopback && loopback.version && loopback.version.split('.')[0]) || 1;
 
   if (loopbackMajor < 2) {
-    throw new Error(g.f('{{loopback-component-explorer}} requires ' +
-      '{{loopback}} 2.0 or newer'));
+    throw new Error(
+      g.f(
+        '{{loopback-component-explorer}} requires ' +
+          '{{loopback}} 2.0 or newer'
+      )
+    );
   }
 
   options = _defaults({}, options, {
@@ -129,7 +136,7 @@ function mountSwagger(loopbackApplication, swaggerApp, opts) {
     swaggerObject = createSwaggerObject(loopbackApplication, opts);
   });
 
-  var resourcePath = opts && opts.resourcePath || 'swagger.json';
+  var resourcePath = (opts && opts.resourcePath) || 'swagger.json';
   if (resourcePath[0] !== '/') resourcePath = '/' + resourcePath;
 
   var remotes = loopbackApplication.remotes();
@@ -142,17 +149,18 @@ function mountSwagger(loopbackApplication, swaggerApp, opts) {
 
 function setupCors(swaggerApp, remotes) {
   var corsOptions = remotes.options && remotes.options.cors;
-  if (corsOptions === false)
-    return;
+  if (corsOptions === false) return;
 
-  deprecated(g.f(
-    'The built-in CORS middleware provided by loopback-component-explorer ' +
-      'was deprecated. See %s for more details.',
-    'https://docs.strongloop.com/display/public/LB/Security+considerations'
-  ));
+  deprecated(
+    g.f(
+      'The built-in CORS middleware provided by loopback-component-explorer ' +
+        'was deprecated. See %s for more details.',
+      'https://loopback.io/doc/en/lb3/Security-considerations.html'
+    )
+  );
 
   if (corsOptions === undefined) {
-    corsOptions = { origin: true, credentials: true };
+    corsOptions = {origin: true, credentials: true};
   }
 
   swaggerApp.use(cors(corsOptions));

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   },
   "devDependencies": {
     "chai": "^3.2.0",
-    "eslint": "^2.8.0",
-    "eslint-config-loopback": "^2.0.0",
+    "eslint": "^3.11.0",
+    "eslint-config-loopback": "^8.0.0",
     "loopback": "^3.0.0",
     "mocha": "^2.2.5",
     "supertest": "^1.0.1"


### PR DESCRIPTION
> There are links to docs.strongloop.com in various places in the code that we should replace with links to the new doc site loopback.io/doc.
Originated from: https://github.com/strongloop-internal/scrum-loopback/issues/1108

2 changes in this PR and the rest are coming from the linter:
- update link in `index.js` point to https://loopback.io/doc/en/lb3/Security-considerations.html
- update the eslint version in package.json.  The versions are used in `generator-loopback` as well (https://github.com/strongloop/generator-loopback/blob/master/package.json#L57)