### PR TITLE
Fix lodash vulnerability: Prototype Pollution

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "cors": "^2.7.1",
     "debug": "^2.2.0",
     "depd": "^1.1.0",
-    "lodash": "^3.10.0",
+    "lodash": "^4.17.5",
     "loopback-swagger": "^3.0.1",
     "strong-globalize": "^2.6.2",
     "swagger-ui": "^2.2.5"


### PR DESCRIPTION
### Description
I was using `loopback-component-explorer@4.3.0` and having a NSP vulnerability warning (Ref: https://nodesecurity.io/advisories/577)

These are the compatibility-warnings for upgrading `lodash` from v3 to v4 (https://github.com/lodash/lodash/wiki/Changelog#compatibility-warnings)
