### PR TITLE
update swagger-ui version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "lodash": "^4.17.5",
     "loopback-swagger": "^5.0.0",
     "strong-globalize": "^4.1.1",
-    "swagger-ui": "^3.19.0"
+    "swagger-ui": "^2.2.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "lodash": "^4.17.5",
     "loopback-swagger": "^5.0.0",
     "strong-globalize": "^4.1.1",
-    "swagger-ui": "^2.2.5"
+    "swagger-ui": "^3.19.0"
   }
 }


### PR DESCRIPTION
### Description
When running `npm i` in this module, I got the following warning:
```
npm WARN deprecated swagger-ui@2.2.10: No longer maintained, please upgrade to swagger-ui@3.
```
This PR will update swagger-ui version in package.json.
