### PR TITLE
Prevent accidental upgrades to swagger-ui v3+

### DIFF
--- a/test/explorer.test.js
+++ b/test/explorer.test.js
@@ -5,6 +5,21 @@
 
 'use strict';
 
+// NOTE(bajtos) It's important to run this check before we load the Explorer
+// because require() may fail (e.g. with MODULE_NOT_FOUND error) and make
+// it difficult to identify the actual problem
+const uiVersion = require('../package.json').dependencies['swagger-ui'];
+if (!uiVersion.startsWith('^2')) {
+  console.error(`
+Upgrading from swagger-ui@2 to a newer major version (${uiVersion}) is difficult,
+see https://github.com/strongloop/loopback-component-explorer/issues/254
+If you are confident about this change and have manually verified API Explorer
+functionality in the browser, including access-token based authentication,
+then you can delete this check.
+`);
+  process.exit(2);
+}
+
 const loopback = require('loopback');
 const explorer = require('../');
 const request = require('supertest');


### PR DESCRIPTION
To prevent accidental upgrades to a new (and very incompatible) version of swagger-ui, I am proposing to add an explicit version check that will abort the test suite when upgrade is detected.

```
$ npm t

> loopback-component-explorer@6.3.1 test /Users/bajtos/src/loopback/component-explorer
> mocha


Upgrading from swagger-ui@2 to a newer major version is difficult, see
https://github.com/strongloop/loopback-component-explorer/issues/254
If you are confident about this change and have manually verified API Explorer
functionality in the browser, including access-token based authentication,
then you can delete this check.

npm ERR! Test failed.  See above for more details.
```

See #250, #253 and and #254.