### PR TITLE
update README for LTS status

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,6 @@ Module Long Term Support (LTS)](http://github.com/CloudNativeJS/ModuleLTS) polic
 | ------- | --------------- | --------- | -------- |
 | 6.x     | Active LTS      | Apr 2018  | Dec 2019 |
 | 5.x     | Maintenance LTS | Sep 2017  | Dec 2019 |
-| 4.x     | Maintenance LTS | Dec 2016  | Apr 2019 |
+| 4.x     | End-of-Life     | Dec 2016  | Apr 2019 |
 
 Learn more about our LTS plan in [docs](https://loopback.io/doc/en/contrib/Long-term-support.html).

--- a/example/hidden.js
+++ b/example/hidden.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Copyright IBM Corp. 2014,2019. All Rights Reserved.
 // Node module: loopback-component-explorer
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/example/simple.js
+++ b/example/simple.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-component-explorer
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-component-explorer
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/lib/url-join.js
+++ b/lib/url-join.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014. All Rights Reserved.
+// Copyright IBM Corp. 2014,2019. All Rights Reserved.
 // Node module: loopback-component-explorer
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "api",
     "explorer"
   ],
-  "author": "Ritchie Martori",
+  "author": "IBM Corp.",
   "readmeFilename": "README.md",
   "bugs": {
     "url": "https://github.com/strongloop/loopback-component-explorer/issues"

--- a/public/lib/loadSwaggerUI.js
+++ b/public/lib/loadSwaggerUI.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Copyright IBM Corp. 2014,2018. All Rights Reserved.
 // Node module: loopback-component-explorer
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/explorer.test.js
+++ b/test/explorer.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Copyright IBM Corp. 2013,2019. All Rights Reserved.
 // Node module: loopback-component-explorer
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/test/fixtures/dummy-swagger-ui/swagger-ui.js
+++ b/test/fixtures/dummy-swagger-ui/swagger-ui.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014. All Rights Reserved.
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
 // Node module: loopback-component-explorer
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT


### PR DESCRIPTION
### Description
Related to https://github.com/strongloop/loopback/issues/4180

- Update `README` for the LTS status
- Update `package.json` `author` attribute so that the `slt copyright` command can generate the right copyright header
- Run `slt copyright` command to update the copyright years
