### PR TITLE
Update swagger-ui dependency to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "lodash": "^4.17.11",
     "loopback-swagger": "^5.0.0",
     "strong-globalize": "^4.1.1",
-    "swagger-ui": "^2.2.5"
+    "swagger-ui": "^3.23.11"
   }
 }


### PR DESCRIPTION
Update swagger-ui dependency to version ^3.23.11 to fix three moderate
vulnerabilities referenced in:
* [Reverse Tabnapping](https://www.npmjs.com/advisories/975)
* [Cross-Site Scripting](https://www.npmjs.com/advisories/976)
* [Cross-Site Scripting](https://www.npmjs.com/advisories/985)
